### PR TITLE
Update Sublime / Textmate syntax highlighting.

### DIFF
--- a/Dart.tmbundle/Syntaxes/Dart.textmate
+++ b/Dart.tmbundle/Syntaxes/Dart.textmate
@@ -7,14 +7,14 @@
 			match = '^(#!.*)$';
 		},
 		{	name = 'meta.declaration.dart';
-			begin = '\b(library|import|part of|part|show|hide)\b';
+			begin = '\b(library|import|part of|part)\b';
 			end = ';';
 			beginCaptures = { 0 = { name = 'keyword.other.import.dart'; }; };
 			endCaptures = { 0 = { name = 'punctuation.terminator.dart'; }; };
 			patterns = (
 				{	include = '#strings'; },
-				{	match = '\b(prefix)\s*:';
-					captures = { 1 = { name = 'keyword.other.import.dart'; }; };
+				{	name = 'keyword.other.import.dart';
+					match = '\b(as|show|hide)\b';
 				},
 			);
 		},

--- a/Dart.tmbundle/Syntaxes/Dart.tmLanguage
+++ b/Dart.tmbundle/Syntaxes/Dart.tmLanguage
@@ -50,16 +50,10 @@
 					<string>#strings</string>
 				</dict>
 				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.import.dart</string>
-						</dict>
-					</dict>
 					<key>match</key>
-					<string>\b(prefix)\s*:</string>
+					<string>\b(as|show|hide)\b</string>
+					<key>name</key>
+					<string>keyword.other.import.dart</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Update Textmate / Sublime's syntax highlighting for Dart. Removed `source` and `resource` keywords, removed need for `#` before `library` and `import`, added the `part` and `part of` keywords, changed so that raw strings start with `r` instead of `@`.
