### PR TITLE
Support for multiline strings with single-quotes

### DIFF
--- a/Dart.tmbundle/Syntaxes/Dart.textmate
+++ b/Dart.tmbundle/Syntaxes/Dart.textmate
@@ -131,14 +131,23 @@
 		};
 		strings = {
 			patterns = (
-				{	name = 'string.interpolated.triple.dart';
+				{	name = 'string.interpolated.triple.double.dart';
 					begin = '(?<!r)"""';
 					end = '"""(?!")';
 					patterns = ( { include = '#string-interp'; } );
 				},
-				{	name = 'string.quoted.triple.dart';
+				{	name = 'string.interpolated.triple.single.dart';
+					begin = "(?<!r)'''";
+					end = "'''(?!')";
+					patterns = ( { include = '#string-interp'; } );
+				},
+				{	name = 'string.quoted.triple.double.dart';
 					begin = 'r"""';
 					end = '"""(?!")';
+				},
+				{	name = 'string.quoted.triple.single.dart';
+					begin = "r'''";
+					end = "'''(?!')";
 				},
 				{	name = 'string.interpolated.double.dart';
 					begin = '(?<!\\|r)"';

--- a/Dart.tmbundle/Syntaxes/Dart.tmLanguage
+++ b/Dart.tmbundle/Syntaxes/Dart.tmLanguage
@@ -307,7 +307,22 @@
 					<key>end</key>
 					<string>"""(?!")</string>
 					<key>name</key>
-					<string>string.interpolated.triple.dart</string>
+					<string>string.interpolated.triple.double.dart</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#string-interp</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?&lt;!r)'''</string>
+					<key>end</key>
+					<string>'''(?!')</string>
+					<key>name</key>
+					<string>string.interpolated.triple.single.dart</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -322,7 +337,15 @@
 					<key>end</key>
 					<string>"""(?!")</string>
 					<key>name</key>
-					<string>string.quoted.triple.dart</string>
+					<string>string.quoted.triple.double.dart</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>r'''</string>
+					<key>end</key>
+					<string>'''(?!')</string>
+					<key>name</key>
+					<string>string.quoted.triple.single.dart</string>
 				</dict>
 				<dict>
 					<key>begin</key>


### PR DESCRIPTION
Adding proper syntax highlighting for multiline strings using single-quotes (multiline strings with double-quotes were already supported).

```
var x = '''
Hello World!
''';
```
