### PR TITLE
Fix Pub Support Plugin

### DIFF
--- a/pub_support.py
+++ b/pub_support.py
@@ -40,7 +40,7 @@ class PubThread(threading.Thread):
 
         print 'pub install %s' % self.fileName
         proc = subprocess.Popen([pub_path, 'install'], cwd=working_directory,
-            shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         out, _ = proc.communicate()
         
         if proc.returncode != 0:


### PR DESCRIPTION
This plugin isn't working for me because Popen either takes an array containing the command its args when shell=False, or a string with commands and args when shell=True. Currently we are passing in an array, but shell=True. This just changes it back to the default shell=False, which fixes the problem.
