### PR TITLE
strip 'file:' from analyzer's output so that Sublime Text can locate the...

### DIFF
--- a/Dart.sublime-build
+++ b/Dart.sublime-build
@@ -2,7 +2,7 @@
     // Default: dart2js
     "cmd": ["dart2js", "--minify", "-o$file.js", "$file"],
     // xyz/test.dart:5:1: Warning: cannot resolve type foo
-    "file_regex": "file:(\\S*):(\\d*):(\\d*): (.*)",
+    "file_regex": "file:/(\\S*):(\\d*):(\\d*): (.*)",
     "selector": "source.dart",
     "working_dir": "${project_path:${folder}}",
 


### PR DESCRIPTION
... offending file

(Fixed on a Windows machine.)

Two things to note:

The dart analyzer returns an error string in this format:

```
file:/C:/Users/Guillermo/Desktop/foo.dart:5:1: Unexpected token '}' (expected ';')
 4:     print("HELLO $name")
 5: }
    ~
Compilation failed with 1 problem.
```
- It seems the reported path should rather look like this: `file:///...` Is that an issue in the analyzer?
- S3 does not understand the `file:///` protocol.
- S3 will fail at locating the file+line+col anyway because `/C:/...` trips it up. It only understands `/C/...`.

Lastly, I'm pretty new to Dart, so perhaps I'm not making too much sense...
