### PR TITLE
remove javadoc, dart comments don't use javadoc

### DIFF
--- a/Dart.JSON-tmLanguage
+++ b/Dart.JSON-tmLanguage
@@ -30,7 +30,6 @@
 					match = '/\*\*/';
 					captures = { 0 = { name = 'punctuation.definition.comment.dart'; }; };
 				},
-				{	include = 'text.html.javadoc'; },
 				{	include = '#comments-inline'; },
 			);
 		};

--- a/Dart.tmLanguage
+++ b/Dart.tmLanguage
@@ -96,10 +96,6 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>text.html.javadoc</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#comments-inline</string>
 				</dict>
 			</array>


### PR DESCRIPTION
This is causing some comments to parse incorrectly, for example, this line of Polymer.dart:

https://github.com/dart-lang/bleeding_edge/blob/258a424a4f915889fa50d557c00820a3c6154ab3/dart/pkg/polymer/lib/polymer.dart#L22

Sublime gets really confused by the `<0` and code is messed up even after the comment, which makes editing hard :). I also see Dart annotations like `@observable` highlighted incorrectly.

Dart documentation comments use a different syntax from javadoc, see: https://www.dartlang.org/articles/doc-comment-guidelines/

@sethladd @timothyarmstrong -- do you mind reviewing?

btw, I wasn't sure about the -JSON.tmLanguage file. I tried to edit it first and use `plutil` to generate the plist file, but it caused other differences. I'm not sure if the 2 files have diverged or if I'm using the wrong command to build that file, so I just manually edited both.
