### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ BUILD SYSTEM USAGE
 
 LINTER USAGE
 ============
-By default the dartanalyzer feedback is turned off.  If you would like to use this feature you will need to change the `dartlint_active` setting to `True`.
+By default the dartanalyzer feedback is turned off.  If you would like to use this feature you will need to change the `dartlint_active` setting to `true`.
 
     {
         ...
         
-        "dartlint_active" : True, 
+        "dartlint_active" : true, 
         
         ...
     }


### PR DESCRIPTION
Should be lower case as it is JSON. But I still don't know how to use the linter. Even in files that I know that they have warnings and hints, nothing is displayed. Do I need to trigger it somehow?
