### PR TITLE
Add mappings to continue comments on the next line when pressing 'enter'...

### DIFF
--- a/Support/Default.sublime-keymap
+++ b/Support/Default.sublime-keymap
@@ -1,27 +1,15 @@
 [
 	{
-		"keys": ["enter"],
-		"command": "insert_snippet",
-		"args": {
-			"contents": "\n* $0"
-		},
-		"context": [{ "key": "selector", 
-									"operator": "equal",
-									"operand": "comment.block.dart",
-									"match_all": true }
-					]
+		"keys": ["enter"], "command": "insert_snippet", "args": { "contents": "\n* $0" },
+		"context": [
+			{ "key": "selector", "operator": "equal", "operand": "comment.block.dart", "match_all": true }
+			]
 	},
 
 	{
-		"keys": ["enter"],
-		"command": "insert_snippet",
-		"args": {
-			"contents": "\n// $0"
-		},
-		"context": [{ "key": "preceding_text",
-									"match_all": true,
-									"operator": "regex_match",
-									"operand": "^\\s*//.*" }
-					]
+		"keys": ["enter"], "command": "insert_snippet", "args": { "contents": "\n// $0" },
+		"context": [
+			{ "key": "preceding_text", "match_all": true, "operator": "regex_match", "operand": "^\\s*//.*" }
+			]
 	}
 ]


### PR DESCRIPTION
Adds mappings limited to line and block comments that will insert
'//' or ' *' as needed on the next line when pressing 'enter' to
continue comments.
