### PR TITLE
Add settings to match Dart code style conventions.

### DIFF
--- a/Support/Dart.sublime-settings
+++ b/Support/Dart.sublime-settings
@@ -2,7 +2,7 @@
 	// The path to the dart-sdk.
 	"dartsdk_path" : "",
 	// Dartlint plugin settings
-	"dartlint_active" : false, 
+	"dartlint_active" : false,
 	"dartlint_on_load" : true,
 	"dartlint_on_save" : true,
 	"dartlint_show_popup_level" : "WARNING",
@@ -13,5 +13,10 @@
 	// Underline colors
 	"dartlint_underline_color_error" : "C7321C",
 	"dartlint_underline_color_warning" : "F18512",
-	"dartlint_underline_color_info" : "0000FC"
+	"dartlint_underline_color_info" : "0000FC",
+
+	// Dart standard code style conventions.
+	"tab_size": 2,
+	"translate_tabs_to_spaces": true,
+	"rulers": [80]
 }


### PR DESCRIPTION
Based on DartEditor defaults.
- Use spaces for indentation
- Tab size is 2 spaces
- Set default ruler for .dart files at 80th column
