### PR TITLE
Add .gitattributes file.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+# * text=auto
+
+# These files need to have LF as line terminator, even on Windows.
+*.tmSnippet text eol=lf
+


### PR DESCRIPTION
Some ST resources need to have LF terminators to work as intented.
For example, letting Git handle line terminators automatically
causes problems with _.tmSnippet_ files on Windows: LFs in the repo
get converted into CRLFs on Windows, and when you try to insert a
snippet on Windows, you get extraneous CR characters in your file.

A _.gitattributes_ file allows us to specify line terminator
conversion based on file extension.
