### PR TITLE
Add settings for SublimeLinter3 (Python linter)

### DIFF
--- a/Dart.sublime-project
+++ b/Dart.sublime-project
@@ -7,7 +7,8 @@
 		}
 	],
 
-	"settings":
+	"SublimeLinter":
 	{
+		"@python": 3.4
 	}
 }


### PR DESCRIPTION
This setting will be ignored for plugin devs who are not using SublimeLinter3 for Python.

The linter (pylint in my case) should check for any 3.x version errors. Using version 3.4 is arbitrary, but you have to choose one and, while it's ahead of ST's interpreter (3.3 at present), I think it's a reasonable requirement.
