### PR TITLE
Add 'Browse API Reference' command to Command Palette

### DIFF
--- a/Support/Dart.sublime-commands
+++ b/Support/Dart.sublime-commands
@@ -1,0 +1,3 @@
+[
+    { "caption": "Dart: Browse API Reference", "command": "open_browser", "args": {"url": "https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/home" } }
+]

--- a/Support/Default.sublime-keymap
+++ b/Support/Default.sublime-keymap
@@ -11,5 +11,9 @@
 		"context": [
 			{ "key": "preceding_text", "match_all": true, "operator": "regex_match", "operand": "^\\s*//.*" }
 			]
+	},
+
+	{
+		"keys": ["ctrl+.", "ctrl+."], "command": "show_overlay", "args": { "overlay": "command_palette", "text": "Dart: " }
 	}
 ]

--- a/misc.py
+++ b/misc.py
@@ -1,0 +1,8 @@
+import sublime_plugin
+
+import webbrowser
+
+
+class OpenBrowser(sublime_plugin.WindowCommand):
+    def run(self, url):
+        webbrowser.open_new_tab(url)


### PR DESCRIPTION
Fixes #101 (partially)

Adds:
- `.sublime-commands` file with a 'Browse API Reference' command
-  <kbd>Ctrl+.</kbd>, <kbd>Ctrl+.</kbd> to open the Command Palette and see 'Dart: ' commands
- `.py` file so support 'Browse API Reference' command

TODO: If merged, documentation about available commands in the Command Palette.

(BTW, having to edit the docs online is very inconvenient. Could  at least the wiki be public to contributors?)
