### PR TITLE
Integrate tests with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+python:
+    - "3.3"
+
+env:
+    global:
+        - PACKAGE="Dart"
+    matrix:
+        - SUBLIME_TEXT_VERSION="3"
+
+install:
+    - sh -e travis.sh $SUBLIME_TEXT_VERSION $PACKAGE
+
+before_script:
+    - export DISPLAY=:99.0
+    - sh -e /etc/init.d/xvfb start
+
+script:
+    - python $HOME/.config/sublime-text-$SUBLIME_TEXT_VERSION/Packages/UnitTesting/sbin/run.py $PACKAGE
+
+notifications:
+    email: false

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+export SUBLIME_TEXT_VERSION=$1
+export PACKAGE="$2"
+export STP=$HOME/.config/sublime-text-$SUBLIME_TEXT_VERSION/Packages
+
+if [ -z $(which subl) ]; then
+    if [ $SUBLIME_TEXT_VERSION -eq 2 ]; then
+        echo installing sublime 2
+        sudo add-apt-repository ppa:webupd8team/sublime-text-2 -y
+        sudo apt-get update
+        sudo apt-get install sublime-text -y
+    elif [ $SUBLIME_TEXT_VERSION -eq 3 ]; then
+        echo installing sublime 3
+        sudo add-apt-repository ppa:webupd8team/sublime-text-3 -y
+        sudo apt-get update
+        sudo apt-get install sublime-text-installer -y
+    fi
+fi
+
+if [ ! -d $STP ]; then
+    echo creating sublime package directory
+    mkdir -p $STP
+fi
+
+if [ ! -d $STP/$PACKAGE ]; then
+    echo symlink the package to sublime package directory
+    ln -s $PWD $STP/$PACKAGE
+fi
+
+if [ ! -d $STP/UnitTesting ]; then
+    echo download latest UnitTesting release
+    # for stability, you may consider a fixed version of UnitTesting, eg TAG=0.1.4
+    TAG=`git ls-remote --tags https://github.com/randy3k/UnitTesting | sed 's|.*/\([^/]*$\)|\1|' | sort -r | head -1`
+    git clone --branch $TAG https://github.com/randy3k/UnitTesting $STP/UnitTesting
+fi


### PR DESCRIPTION
After this pull request, Travis should be able to run the tests for this package.

I suppose an admin must do the following (maybe I can do it myself, I haven't checked):
- Log in to Travis
- Enable building the official repository
- Sticking a badge in the README

External dependencies:
- UnitTesting package for Sublime Text
