### PR TITLE
Fix : Remove ambiguous rule targeting functions

### DIFF
--- a/Dart.tmLanguage
+++ b/Dart.tmLanguage
@@ -351,35 +351,6 @@
 						</dict>
 					</array>
 				</dict>
-				<dict>
-					<key>begin</key>
-					<string>^\s*(\w+)(?=\()\((?=.*?(?:\{|=&gt;))</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>function.name.dart</string>
-						</dict>
-					</dict>
-					<key>comment</key>
-					<string>A function with no return type.</string>
-					<key>end</key>
-					<string>\)</string>
-					<key>name</key>
-					<string>meta.declaration.function.dart</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>#decl-function-parameter</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#keywords</string>
-						</dict>
-					</array>
-				</dict>
 			</array>
 		</dict>
 		<key>decl-function-parameter</key>


### PR DESCRIPTION
Remove rule targeting functions with no return type. It is too
ambiguous and breaks syntax highlighting when calling functions,
because they get misrecognized as function definitions.
