### PR TITLE
Fix #122: Fix highlighting of ternary operator

### DIFF
--- a/Dart.tmLanguage
+++ b/Dart.tmLanguage
@@ -568,7 +568,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\?|:</string>
+					<string>\s+\?\s+|\s+:\s+</string>
 					<key>name</key>
 					<string>keyword.control.ternary.dart</string>
 				</dict>


### PR DESCRIPTION
Add whitespace around operator components. This prevents colons
from getting highlighted as a ternary operator, for example, in
default parameters.
