### PR TITLE
Fix #120: Highlight strings in default parameters

### DIFF
--- a/Dart.tmLanguage
+++ b/Dart.tmLanguage
@@ -279,6 +279,10 @@
 						</dict>
 						<dict>
 							<key>include</key>
+							<string>#strings</string>
+						</dict>
+						<dict>
+							<key>include</key>
 							<string>#keywords</string>
 						</dict>
 					</array>
@@ -313,6 +317,10 @@
 						</dict>
 						<dict>
 							<key>include</key>
+							<string>#strings</string>
+						</dict>
+						<dict>
+							<key>include</key>
 							<string>#keywords</string>
 						</dict>
 					</array>
@@ -344,6 +352,10 @@
 						<dict>
 							<key>include</key>
 							<string>#decl-function-parameter</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#strings</string>
 						</dict>
 						<dict>
 							<key>include</key>
@@ -416,6 +428,10 @@
 						</dict>
 						<dict>
 							<key>include</key>
+							<string>#strings</string>
+						</dict>
+						<dict>
+							<key>include</key>
 							<string>#keywords</string>
 						</dict>
 					</array>
@@ -450,6 +466,10 @@
 						</dict>
 						<dict>
 							<key>include</key>
+							<string>#strings</string>
+						</dict>
+						<dict>
+							<key>include</key>
 							<string>#keywords</string>
 						</dict>
 					</array>
@@ -476,6 +496,10 @@
 						<dict>
 							<key>include</key>
 							<string>#decl-function-parameter</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#strings</string>
 						</dict>
 						<dict>
 							<key>include</key>


### PR DESCRIPTION
Add highlighting of strings in default parameters and nested
'parameter functions'.
