### PR TITLE
Made the Windows "Dart Run" build use checked mode.

### DIFF
--- a/Support/Dart.sublime-build
+++ b/Support/Dart.sublime-build
@@ -89,7 +89,7 @@
             },
             "osx":
             {
-                "cmd": ["/bin/bash", "--login", "-c", "dart $file"]
+                "cmd": ["/bin/bash", "--login", "-c", "dart --checked $file"]
             }
         }
     ]


### PR DESCRIPTION
Default behavior in the Dart Editor is to run in checked mode, and I'd like to run it from Sublime in checked mode as well. Added `-c` the parameter to the build system.
