### PR TITLE
Better I/O scheduling for linter

### DIFF
--- a/dartlint.py
+++ b/dartlint.py
@@ -29,8 +29,8 @@ from .lib.panels import OutputPanel
 
 _logger = PluginLogger(__name__)
 
-# Maps buffer ids to their only valid linter operation token.
-g_operations_tokens = defaultdict(lambda: None)
+# Maps buffer ids to their single valid result token.
+g_result_tokens = defaultdict(lambda: None)
 g_tokens_lock = threading.Lock()
 g_edits_lock = threading.Lock()
 # Holds linter results that need to be relayed to the user. Since the Dart
@@ -375,9 +375,9 @@ class DartLintThread(threading.Thread):
         # We've got a new linter result.
         with g_tokens_lock:
             now = datetime.now()
-            g_operations_tokens[self.view.buffer_id()] = (now.minute * 60 + now.second)
+            g_result_tokens[self.view.buffer_id()] = (now.minute * 60 + now.second)
             lines = errs.decode('utf-8').split(os.linesep)
-            g_linter_results.put((g_operations_tokens[self.view.buffer_id()],
+            g_linter_results.put((g_result_tokens[self.view.buffer_id()],
                              self.view.buffer_id(), lines))
 
 
@@ -418,7 +418,7 @@ class UIUpdater(threading.Thread):
             try:
                 token, buffer_id, lines = g_linter_results.get(0.1)
                 with g_tokens_lock:
-                    if token == g_operations_tokens[buffer_id]:
+                    if token == g_result_tokens[buffer_id]:
                         return lines
             except queue.Empty as e:
                 return None


### PR DESCRIPTION
This a work in progress and **not ready for merging**.

The linter, while extremely useful, offers a rough experience and slows ST down in some scenarios — especially if you switch to a project with many open Dart files.

This PR addresses the perf problem and some user experience issues, mainly:
#### Performance

Now there is a _producer_ thread and a _consumer_ thread exchanging error data. They communicate via a synchronized queue.

The _error producer_ fires when a view is activated or saved. I've disabled linting _on_loaded_ because it was causing serious perf degradation.

The _error consumer_ goes about its business in intervals. It checks the queue for new items and acts upon them. Since it's an async communication, a token and a buffer id is passed along with error data to identify the most current lint operation for the buffer underlying the current view. Results with expired tokens are discarded.
#### Experience

No output panel is shown if there are no errors.
#### Conclusion

All in all, I'm observing better performance and a less jarring experience.

There's some refactoring left to be done and it'd be great if others could test this branch and share their opinion.
