### PR TITLE
Add key binding

### DIFF
--- a/Support/Default.sublime-keymap
+++ b/Support/Default.sublime-keymap
@@ -3,7 +3,8 @@
 		"keys": ["enter"], "command": "insert_snippet", "args": { "contents": "\n* $0" },
 		"context": [
 			{ "key": "selector", "operator": "equal", "operand": "comment.block.dart", "match_all": true },
-			{ "key": "auto_complete_visible", "operand": false }
+			{ "key": "auto_complete_visible", "operand": false },
+			{ "key": "setting.command_mode", "operand": false }
 			]
 	},
 
@@ -11,11 +12,25 @@
 		"keys": ["enter"], "command": "insert_snippet", "args": { "contents": "\n// $0" },
 		"context": [
 			{ "key": "preceding_text", "match_all": true, "operator": "regex_match", "operand": "^\\s*//.*" },
-			{ "key": "auto_complete_visible", "operand": false }
+			{ "key": "auto_complete_visible", "operand": false },
+			{ "key": "setting.command_mode", "operand": false }
 			]
 	},
 
 	{
-		"keys": ["ctrl+.", "ctrl+."], "command": "show_overlay", "args": { "overlay": "command_palette", "text": "Dart: " }
+		"keys": ["ctrl+.", "ctrl+."], "command": "show_overlay",
+			"args": { "overlay": "command_palette", "text": "Dart: " },
+		"context": [
+			{ "key": "setting.command_mode", "operand": false }
+		]
+	},
+
+	{
+		"keys": ["ctrl+shift+.", "ctrl+shift+."], "command": "show_overlay",
+			"args": { "overlay": "command_palette", "text": "Build: Dart: " },
+		"context":
+		[
+			{ "key": "setting.command_mode", "operand": false }
+		]
 	}
 ]


### PR DESCRIPTION
- Limit key bindings to command_mode == false

This should improve cooperation with other plugins (for example,
Vim emulation.)
- Add `Ctrl+Shift+., Ctrl+Shift+.`.

Shows all 'Build: Dart:*' items in the command palette.

**TODO**
- [ ] Update docs
