### PR TITLE
Fix #247 - Check whether expected project paths exist

### DIFF
--- a/lib/dart_project.py
+++ b/lib/dart_project.py
@@ -162,6 +162,7 @@ class DartView(object):
                     return True
 
     def has_prefix(self, prefix):
+        assert(prefix, 'cannot call with empty prefix')
         return is_prefix(prefix, self.view.file_name())
 
     @property


### PR DESCRIPTION
Until now, we were assuming that the 'web' and 'bin' path always
existed. Now we check whether they actually exist.
