### PR TITLE
Fix #268 - On OSX, dart_dartium_path must point to Chromium.app

### DIFF
--- a/Support/Dart - Plugin Settings.sublime-settings
+++ b/Support/Dart - Plugin Settings.sublime-settings
@@ -5,7 +5,7 @@
 	// Path to the sdk directory.
 	"dart_sdk_path": null,
 	// Path to the directory containing Dartium.
-	// In OSX, it's the directory containing Chromium.app.
+	// On OSX, it's the full path to Chromium.app.
 	"dart_dartium_path": null,
 
 	// User-defined browsers.

--- a/lib/path.py
+++ b/lib/path.py
@@ -104,4 +104,3 @@ def to_platform_path(original, append):
             return original + append
         return join(original, append)
     return original
-

--- a/lib/sdk.py
+++ b/lib/sdk.py
@@ -141,7 +141,7 @@ class SDK(object):
         # Dartium will not always be available on the user's machine.
         bin_name = 'chrome.exe'
         if sublime.platform() == 'osx':
-            bin_name = 'Chromium.app/Contents/MacOS/Chromium'
+            bin_name = 'Contents/MacOS/Chromium'
         elif sublime.platform() == 'linux':
             bin_name = 'chrome'
 

--- a/tests/lib/test_sdk.py
+++ b/tests/lib/test_sdk.py
@@ -3,10 +3,3 @@ import sublime
 import unittest
 from unittest import mock
 import os
-
-
-from Dart.lib.sdk import SDK
-
-
-class Test_path_to_default_user_browser(unittest.TestCase):
-    pass


### PR DESCRIPTION
 #268 
