### PR TITLE
Add command palette item to stop running services

### DIFF
--- a/Support/Dart.sublime-commands
+++ b/Support/Dart.sublime-commands
@@ -11,5 +11,7 @@
     { "caption": "Preferences: Dart Settings - User", "command": "dart_open_settings", "args": {"kind": "user"} },
     { "caption": "Preferences: Dart Settings - File Type (User)", "command": "dart_open_settings", "args": {"kind": "user", "scope": "file_type"} },
 
-    { "caption": "Dart: Show Observatory (Server Apps)", "command": "dart_show_server_observatory" }
+    { "caption": "Dart: Show Observatory (Server Apps)", "command": "dart_show_server_observatory" },
+
+    { "caption": "Dart: Stop Running Services", "command": "dart_stop_services" }
 ]


### PR DESCRIPTION
The new command 'Dart: Stop Running Services' will stop any pub
server or observatory instance launched by this plugin.
