### PR TITLE
Added additional args to Dartium launch

### DIFF
--- a/build.py
+++ b/build.py
@@ -269,7 +269,17 @@ class DartRunCommand(DartBuildCommandBase):
         DartRunCommand.server_running = True
 
         # TODO(guillermooo): run dartium in checked mode
-        sublime.set_timeout(lambda: Dartium().start('http://localhost:8080'),
+        user_home = os.path.expanduser("~")
+        args = [
+            '--user-data-dir=' + user_home + '/.dartium',
+            '--enable-experimental-web-platform-features',
+            '--enable-html-imports',
+            '--no-first-run',
+            '--no-default-browser-check',
+            '--no-process-singleton-dialog',
+            '--enable-avfoundation',
+            ]
+        sublime.set_timeout(lambda: Dartium().start('http://localhost:8080', *args),
                             1000)
 
     def stop_server_observatory(self):


### PR DESCRIPTION
This makes launching Dartium from Sublime act much more like when Dartium is launched from the Eclipse editor. Side effects include getting rid of a bunch of potentially annoying startup and "first run" dialogs.
