### PR TITLE
Fix #316 - Add 'Dart: Show Output Panel' command palette item.

### DIFF
--- a/Support/Dart.sublime-commands
+++ b/Support/Dart.sublime-commands
@@ -13,5 +13,8 @@
     { "caption": "Dart: Run In Observatory (Server Apps)", "command": "dart_run_in_observatory" },
 
     { "caption": "Dart: Stop Running Services", "command": "dart_stop_services" },
-    { "caption": "Dart: Stop Running Scripts", "command": "dart_exec", "args": {"kill": true} }
+    { "caption": "Dart: Stop Running Scripts", "command": "dart_exec", "args": {"kill": true} },
+
+    { "caption": "Dart: Show Output Panel", "command": "show_panel", "args": {"panel": "output.dart.out"} }
+
 ]

--- a/execute.py
+++ b/execute.py
@@ -30,7 +30,7 @@ class DartExecCommand(sublime_plugin.WindowCommand, ProcessListener):
             word_wrap=True,
             syntax="Packages/Text/Plain text.tmLanguage",
             preamble='',
-            panel_name='dart',
+            panel_name='dart.out',
             # Catches "path" and "shell"
             **kwargs):
 


### PR DESCRIPTION
Scripts and server apps run from within ST will most likely print
text to an ST panel. This panel may be hidden accidentally by the
user (for example, by pressing Esc). This new command palette
item will reopen the main output panel used by the plugin.
