### PR TITLE
fix path to dart binary when starting the analysis server

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -339,7 +339,7 @@ class AnalysisServer(object):
 
         _logger.info('starting AnalysisServer')
 
-        AnalysisServer.server = PipeServer(['dart',
+        AnalysisServer.server = PipeServer([sdk.path_to_dart,
                             sdk.path_to_analysis_snapshot,
                            '--sdk={0}'.format(sdk.path)])
         AnalysisServer.server.start(working_dir=sdk.path)


### PR DESCRIPTION
The analysis server should be able to run even if the user doesn't have the `dart` program on their `PATH`.