### PR TITLE
Update Comments.tmPreferences

### DIFF
--- a/Support/Comments.tmPreferences
+++ b/Support/Comments.tmPreferences
@@ -24,15 +24,9 @@
 			</dict>
 			<dict>
 				<key>name</key>
-				<string>TM_COMMENT_BLOCK_START</string>
+				<string>TM_COMMENT_START_2</string>
 				<key>value</key>
 				<string>/// </string>
-			</dict>
-			<dict>
-				<key>name</key>
-				<string>TM_LINE_TERMINATOR</string>
-				<key>value</key>
-				<string>;</string>
 			</dict>
 		</array>
 	</dict>


### PR DESCRIPTION
Rename TM_COMMENT_BLOCK_START to TM_COMMENT_START_2 in accordance with ST's comment definition syntax: http://docs.sublimetext.info/en/latest/reference/comments.html.

Fixes #486.
