### PR TITLE
Create analyzer.py

### DIFF
--- a/lib/analyzer/analyzer.py
+++ b/lib/analyzer/analyzer.py
@@ -296,7 +296,7 @@ class AnalysisServer(object):
 
     def should_ignore_file(self, path):
         project = DartProject.from_path(path)
-        is_a_third_party_file = (project and is_path_under(project.path_to_packages, path))
+        is_a_third_party_file = (project and project.path_to_packages and is_path_under(project.path_to_packages, path))
 
         if is_a_third_party_file:
             return True


### PR DESCRIPTION
This tiny patch, which I basically found under one of the bug threads, fixes the "NoneType" error that seems to happen when there is no package directory. I'm totally new to dart, being asked to work on code created by somebody else in Webstorm, and this error threw me for a loop for a minute, but this simple fix seems to have me up and running.